### PR TITLE
Fixes a bug (?) in Lesson.js

### DIFF
--- a/src/components/Lesson.js
+++ b/src/components/Lesson.js
@@ -108,7 +108,7 @@ class Lesson extends Component {
         console.log(choice, this.state.pressedButton)
       }
 
-      return <AnswerButton possibleAnswer={choice} index={index}
+      return <AnswerButton key={index} possibleAnswer={choice} index={index}
       handleAnswerButtonClick={this.handleAnswerButtonClick.bind(this)}
       isCorrectAnswer={isCorrectAnswer} isPressedAnswer={isPressedAnswer} />
     })


### PR DESCRIPTION
On line 111, adds: 
  key={index}
Within AnswerButton tag.

return <AnswerButton key={index} possibleAnswer={choice} index={index}
      handleAnswerButtonClick={this.handleAnswerButtonClick.bind(this)}
      isCorrectAnswer={isCorrectAnswer} isPressedAnswer={isPressedAnswer} />
    })